### PR TITLE
Specify full path to siritTargets

### DIFF
--- a/CMakeModules/siritConfig.cmake.in
+++ b/CMakeModules/siritConfig.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
 
-include(siritTargets)
+include("${CMAKE_CURRENT_LIST_DIR}/siritTargets.cmake")


### PR DESCRIPTION
Without this I get the following error:
```
  include could not find requested file:

    siritTargets
Call Stack (most recent call first):
  CMakeModules/CPM.cmake:307 (find_package)
  CMakeModules/CPM.cmake:801 (cpm_find_package)
  CMakeModules/CPMUtil.cmake:449 (CPMAddPackage)
  CMakeModules/CPMUtil.cmake:206 (AddPackage)
  externals/CMakeLists.txt:71 (AddJsonPackage)
```